### PR TITLE
Ensure failed message is showing when check fails

### DIFF
--- a/ios-showcase-template/deviceTrust/DeviceTrustViewController.swift
+++ b/ios-showcase-template/deviceTrust/DeviceTrustViewController.swift
@@ -116,15 +116,14 @@ class DeviceTrustViewController: UIViewController, UITableViewDataSource, UITabl
         let imageView = cell.imageView!
         let textView = cell.textLabel!
         textView.isEnabled = true
+        textView.text = CHECKS_RESULT[detection.name]![detection.passed]!
         
         // set the text colouring
         if detection.passed {
-            textView.text = CHECKS_RESULT[detection.name]![detection.passed]!
             textView.textColor = GREEN_COLOR
             imageView.image = UIImage(named: "ic_verified_user_white")?.withRenderingMode(UIImageRenderingMode.alwaysTemplate)
             imageView.tintColor = GREEN_COLOR
         } else {
-            textView.text = CHECKS_RESULT[detection.name]![!detection.passed]!
             textView.textColor = RED_COLOR
             imageView.image = UIImage(named: "ic_warning_white")?.withRenderingMode(UIImageRenderingMode.alwaysTemplate)
             imageView.tintColor = RED_COLOR


### PR DESCRIPTION
@wei-lee Mind taking a look? Based on this comment (https://github.com/aerogear/ios-showcase-template/pull/45#pullrequestreview-132161255). Feel free to close this and apply any changes separately, didn't want to clutter the original PR with screenshots.

=== Before the change

* Failed device lock check shows text saying it's enabled
* Failed debugger check says there's no debugger detected
![screen shot 2018-06-26 at 19 55 12](https://user-images.githubusercontent.com/8698527/41933989-54887d4c-797d-11e8-872b-439f63e6ef78.png)

=== After the change
* Correct messages showing.
![screen shot 2018-06-26 at 20 00 53](https://user-images.githubusercontent.com/8698527/41934114-ba1b7e34-797d-11e8-9b4c-1df893fe7241.png)

